### PR TITLE
Made some small changes to get the GUI working

### DIFF
--- a/habitus_ui_interface-main/backend/grid.py
+++ b/habitus_ui_interface-main/backend/grid.py
@@ -107,16 +107,18 @@ class Grid():
 			cluster_list.append(labels)
 		pd.DataFrame({'docs': document_list, 'cluster': cluster_list}).to_csv(filename)
 
-	def copy_document(self, text, cluster_from_index, cluster_to_index):
+	def copy_document(self, document, cluster_from_index, cluster_to_index):
 		cluster_from = self.clusters[cluster_from_index]
 		cluster_to = self.clusters[cluster_to_index]
-		document = [d for d in cluster_from.documents if d.readable == text][0]
+		if type(document) == str: # If the GUI is sending you this, it's going to be the text, not the object
+			document = [d for d in cluster_from.documents if d.readable == text][0]
 		cluster_to.insert(document)
 	
-	def move_document(self, text, cluster_from_index, cluster_to_index):
+	def move_document(self, document, cluster_from_index, cluster_to_index):
 		cluster_from = self.clusters[cluster_from_index]
 		cluster_to = self.clusters[cluster_to_index]
-		document = [d for d in cluster_from.documents if d.readable == text][0]
+		if type(document) == str: # If the GUI is sending you this, it's going to be the text, not the object
+			document = [d for d in cluster_from.documents if d.readable == text][0]
 		cluster_to.insert(document)
 		cluster_from.remove(document)
 		if not cluster_from:

--- a/habitus_ui_interface-main/backend/grid.py
+++ b/habitus_ui_interface-main/backend/grid.py
@@ -107,16 +107,16 @@ class Grid():
 			cluster_list.append(labels)
 		pd.DataFrame({'docs': document_list, 'cluster': cluster_list}).to_csv(filename)
 
-	def copy_document(self, doc_num, cluster_from_index, cluster_to_index):
+	def copy_document(self, text, cluster_from_index, cluster_to_index):
 		cluster_from = self.clusters[cluster_from_index]
 		cluster_to = self.clusters[cluster_to_index]
-		document = cluster_from.document[doc_num]
+		document = [d for d in cluster_from.documents if d.readable == text][0]
 		cluster_to.insert(document)
 	
-	def move_document(self, doc_num, cluster_from_index, cluster_to_index):
+	def move_document(self, text, cluster_from_index, cluster_to_index):
 		cluster_from = self.clusters[cluster_from_index]
 		cluster_to = self.clusters[cluster_to_index]
-		document = cluster_from.documents[doc_num]
+		document = [d for d in cluster_from.documents if d.readable == text][0]
 		cluster_to.insert(document)
 		cluster_from.remove(document)
 		if not cluster_from:

--- a/habitus_ui_interface-main/main2.py
+++ b/habitus_ui_interface-main/main2.py
@@ -87,8 +87,8 @@ class UvicornFrontend(Frontend):
         }
 
     def toggle_copy(self) -> bool:
-        self.grid.copy_on = not self.grid.copy_on
-        return self.grid.copy_on
+        self.copy_on = not self.copy_on
+        return self.copy_on
 
     def trash(self, text: str) -> dict:
         document = self.find_document(text)
@@ -104,7 +104,7 @@ class UvicornFrontend(Frontend):
         return self.show_grid()
 
     def set_name(self, col_index: int, name: str) -> dict:
-        cluster = self.grid.cluster[col_index]
+        cluster = self.grid.clusters[col_index]
         cluster.set_name(name)
         return self.show_grid()
 
@@ -126,12 +126,12 @@ class UvicornFrontend(Frontend):
 
     # This moves the sentence from the currently clicked_col and clicked_row to
     # the new row and column.
-    def move(self, row_index: int, col_index: int, text_index: str) -> dict:
+    def move(self, row_index: str, col_index: int, text: str) -> dict:
         assert col_index >= 0 # We're not deleting sentences in this way.
         if self.copy_on:
-            self.grid.copy_document(text_index, self.clicked_col, col_index)
+            self.grid.copy_document(text, self.clicked_col, col_index)
         else:
-            self.grid.move_document(text_index, self.clicked_col, col_index)
+            self.grid.move_document(text, self.clicked_col, col_index)
         return self.show_grid()
 
 frontend = UvicornFrontend('../process_files/', 6)
@@ -150,8 +150,8 @@ def root(data: DataFrame = Depends(frontend.show_grid)): # Depends( my function 
 @app.get("/drag/{row}/{col}/{sent}")
 async def drag(row: str, col: str, sent: str):
     print(f"Row: {row}\tCol: {col}\tText: {sent}")
-    row, col, sent = int(row), int(col), int(sent)
-    return frontend.move(row, col, sent)
+    # row, col, sent = int(row), int(col), int(sent)
+    return frontend.move(row, int(col), sent)
 
 @app.get("/click/{row}/{col}")
 async def click(row: str, col: str):


### PR DESCRIPTION
I changed move_document -- the app actually returns the string of the row and document, so it was throwing an error when trying to cast to int. (Is there a better way to get from document text to its object?)

I made tiny fixes for typos, e.g., grid.clusters instead of grid.cluster.

Some issues I found: The frozen columns aren't carried over after regeneration, but I thought it was working from the console so maybe it's a GUI issue; you can rename and freeze a column but it gets bumped out if another column is created.