### PR TITLE
Wait in a different way

### DIFF
--- a/habitus_ui_interface-main/main2a.py
+++ b/habitus_ui_interface-main/main2a.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, Depends
 from frontend import Frontend
 from pandas import DataFrame
 from starlette.middleware.cors import CORSMiddleware
+import asyncio
 import time
 import pandas as pd
 import os
@@ -433,7 +434,7 @@ async def recordAnswers(questionSet: str, userID: int):
     print("writing out for ", questionSet)
     frontends[userID].write_out_answers(questionSet)
     if questionSet == 'feedback':
-        time.sleep(60) # Wait 1 minute before removing the front end
+        await asyncio.sleep(60) # Wait 1 minute before removing the front end
         print("logging out ", userID)
         frontends.pop(userID)
 


### PR DESCRIPTION
I *think* the problem was that time.sleep() was too effective and the answering of the questions was held up until after the user was logged out.  There is evidence from the debugger that suggests this order of events (on this computer with this browser and this Python, etc.).  I would recommend a local test as well to see if at least two computers agree.